### PR TITLE
adding support for extensions objects as defined by minikube

### DIFF
--- a/KubeContext.xcodeproj/project.pbxproj
+++ b/KubeContext.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		8A5DB217259535A1004F6EED /* Yams in Frameworks */ = {isa = PBXBuildFile; productRef = 8A5DB216259535A1004F6EED /* Yams */; };
 		8A5DB21D259535D3004F6EED /* SwiftyStoreKit in Frameworks */ = {isa = PBXBuildFile; productRef = 8A5DB21C259535D3004F6EED /* SwiftyStoreKit */; };
 		8A795B772595240E003EA721 /* EonilFSEvents in Frameworks */ = {isa = PBXBuildFile; productRef = 8A795B762595240E003EA721 /* EonilFSEvents */; };
+		A1EF413726E3C811004BA0C2 /* KubeContextLoadMiniKubeContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1EF413626E3C811004BA0C2 /* KubeContextLoadMiniKubeContextTests.swift */; };
 		E422CCAD216E8D0A0008D173 /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = E422CCAC216E8D0A0008D173 /* Config.swift */; };
 		E439374F21791F8A0077CCF1 /* KubeContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E439374E21791F8A0077CCF1 /* KubeContextTests.swift */; };
 		E4393759217926C40077CCF1 /* TestData in Resources */ = {isa = PBXBuildFile; fileRef = E4393757217922E90077CCF1 /* TestData */; };
@@ -46,6 +47,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		A1EF413626E3C811004BA0C2 /* KubeContextLoadMiniKubeContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KubeContextLoadMiniKubeContextTests.swift; sourceTree = "<group>"; };
 		E422CCAC216E8D0A0008D173 /* Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Config.swift; sourceTree = "<group>"; };
 		E439374C21791F8A0077CCF1 /* KubeContextTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = KubeContextTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		E439374E21791F8A0077CCF1 /* KubeContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KubeContextTests.swift; sourceTree = "<group>"; };
@@ -107,6 +109,7 @@
 				E4F96DBA217B3D3E004428F6 /* KubeContextBadFileTests.swift */,
 				E439375021791F8A0077CCF1 /* Info.plist */,
 				E4F96DBE217B552D004428F6 /* UtilsTests.swift */,
+				A1EF413626E3C811004BA0C2 /* KubeContextLoadMiniKubeContextTests.swift */,
 			);
 			path = KubeContextTests;
 			sourceTree = "<group>";
@@ -310,6 +313,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A1EF413726E3C811004BA0C2 /* KubeContextLoadMiniKubeContextTests.swift in Sources */,
 				E4F96DBB217B3D3E004428F6 /* KubeContextBadFileTests.swift in Sources */,
 				E439374F21791F8A0077CCF1 /* KubeContextTests.swift in Sources */,
 				E4F96DBF217B552D004428F6 /* UtilsTests.swift in Sources */,
@@ -538,7 +542,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.1;
-				MARKETING_VERSION = 2.0.0;
+				MARKETING_VERSION = 2.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ht.kubecontext;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -563,7 +567,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.1;
-				MARKETING_VERSION = 2.0.0;
+				MARKETING_VERSION = 2.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ht.kubecontext;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/KubeContext/Config.swift
+++ b/KubeContext/Config.swift
@@ -63,7 +63,7 @@ struct ClusterElement: Codable {
 struct Cluster: Codable {
     var CertificateAuthority: String?
     var CertificateAuthorityData: String?
-    var Extensions: [String:String]?
+    var Extensions: [ExtensionElement]?
     var InsecureSkipTLSVerify: Bool?
     var Server: String
     
@@ -132,9 +132,31 @@ struct ContextElement: Codable {
     }
 }
 
+struct ExtensionElement: Codable {
+    var Extension: Extension
+    var Name: String
+    
+    private enum CodingKeys : String, CodingKey {
+        case Extension="extension"
+        case Name="name"
+    }
+}
+
+struct Extension: Codable {
+    var LastUpdate: String?
+    var Version: String?
+    var Provider: String?
+    
+    private enum CodingKeys : String, CodingKey {
+        case LastUpdate="last-update"
+        case Version="version"
+        case Provider="provider"
+    }
+}
+
 struct Context: Codable {
     var Cluster: String
-    var Extensions: [String:String]?
+    var Extensions: [ExtensionElement]?
     var Namespace: String?
     var AuthInfo: String
     

--- a/KubeContextTests/KubeContextLoadMiniKubeContextTests.swift
+++ b/KubeContextTests/KubeContextLoadMiniKubeContextTests.swift
@@ -1,0 +1,30 @@
+//
+//  KubeContextMiniKube.swift
+//  KubeContextTests
+//
+//  Created by Andy Steinmann on 9/4/21.
+//  Copyright © 2021 Turken, Hasan. All rights reserved.
+//
+
+import XCTest
+@testable import KubeContext
+
+class KubeContextLoadMiniKubeContextTests: XCTestCase {
+    var k8s: Kubernetes?
+    var bundle: Bundle!
+    
+    override func setUp() {
+        bundle = Bundle(for: type(of: self))
+        k8s = Kubernetes()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+    
+    func testLoadMiniKubeFile() {
+        let url = bundle.url(forResource: "minikube", withExtension: "yaml", subdirectory: "TestData")
+        XCTAssertNoThrow(try k8s?.setKubeconfig(configFile: url));
+    }
+}

--- a/KubeContextTests/TestData/minikube.yaml
+++ b/KubeContextTests/TestData/minikube.yaml
@@ -1,0 +1,33 @@
+
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority: /Users/user/.minikube/ca.crt
+    extensions:
+    - extension:
+        last-update: Sat, 04 Sep 2021 10:04:54 CDT
+        provider: minikube.sigs.k8s.io
+        version: v1.23.0
+      name: cluster_info
+    server: https://1.2.3.4:5678
+  name: minikube
+contexts:
+- context:
+    cluster: minikube
+    extensions:
+    - extension:
+        last-update: Sat, 04 Sep 2021 10:04:54 CDT
+        provider: minikube.sigs.k8s.io
+        version: v1.23.0
+      name: context_info
+    namespace: default
+    user: minikube
+  name: minikube
+current-context: minikube
+kind: Config
+preferences: {}
+users:
+- name: minikube
+  user:
+    client-certificate: /Users/user/.minikube/profiles/minikube/client.crt
+    client-key: /Users/user/.minikube/profiles/minikube/client.key


### PR DESCRIPTION
Attempt to fix issue #12.

It appears that Minikube adds a map of extensions.  Updated the Config.swift to reflect this structure.  Also added a test to confirm it works.